### PR TITLE
Fix application does not start on Windows.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3665,8 +3665,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "surge-ping"
-version = "0.7.4"
-source = "git+https://github.com/kolapapa/surge-ping#1a5ae14deadfdf8b064a15de7fde10c941971007"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d1d85515268a4d0c8dd43f79fae4001d0f47cdce006482b7917af4e3b9fcd79"
 dependencies = [
  "hex",
  "parking_lot 0.12.1",

--- a/teamwork-launcher/Cargo.toml
+++ b/teamwork-launcher/Cargo.toml
@@ -2,7 +2,7 @@
 name = "teamwork-launcher"
 version = "0.1.0"
 edition = "2021"
-
+#bui
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -36,4 +36,4 @@ unidecode = "0.3.0"
 enum-as-inner = "0.5.1"
 include_dir = "0.7.3"
 iso_country = "0.1.4"
-surge-ping = { git = "https://github.com/kolapapa/surge-ping" }
+surge-ping = "0.7.3"


### PR DESCRIPTION
This was caused by a panic in the latest surge-ping I was fetching. Using 0.7.3 works on Windows, but I think it will crash on OSX.